### PR TITLE
Move ground animation to its own class

### DIFF
--- a/style/site.css
+++ b/style/site.css
@@ -107,7 +107,7 @@ body {
     overflow: hidden;
 }
 
-.grid-move {
+.grid--move {
     animation: groundmovement 1s linear infinite;
 }
 

--- a/style/site.css
+++ b/style/site.css
@@ -104,8 +104,11 @@ body {
     border-top: 8px solid #ff16a9;
     box-shadow: 0 -2em 16em 0 #ff16a9;
     transform: perspective(100em) rotateX(75deg) translateY(90%);
-    animation: groundmovement 1s linear infinite;
     overflow: hidden;
+}
+
+.grid-move {
+    animation: groundmovement 1s linear infinite;
 }
 
 @keyframes groundmovement {


### PR DESCRIPTION
Since the animation can become quite heavy to run, let's disable it for now. 

It can still be enabled by adding ".grid--move" to the class list for the grid.