### PR TITLE
Remove description styling

### DIFF
--- a/style/all.css
+++ b/style/all.css
@@ -38,12 +38,6 @@ body {
 
 .name {
     color: #fa2573;
-    text-align: center;
-}
-
-.description {
-    color: #8700ff;
-    text-align: center;
 }
 
 .links {


### PR DESCRIPTION
Use default foreground color instead. As we no longer need to align the
text to the center anymore, let's remove it as well.